### PR TITLE
Fpfissupp 4656

### DIFF
--- a/content_purge.vcl
+++ b/content_purge.vcl
@@ -37,7 +37,7 @@ sub handle_simple_purge_requests {
     if (req.url !~ "/+$") {
         ban("req.http.host == " + req.http.host + " && req.url == " + req.url + "/");
     }
-    std.log(req.http.host + req.url + "PURGED");
+    std.log(req.http.host + " " + req.url + " PURGED");
         return (synth(200, "PURGED"));
 }
 
@@ -49,11 +49,11 @@ sub handle_flexible_purge_requests {
         if (req.http.X-Invalidate-Tag) {
             std.log("Tag based purge");
             ban("req.http.X-Application-Tag == " + req.http.X-Invalidate-Tag);
-            std.log(req.http.X-Invalidate-Tag + "PURGED");
+            std.log(req.http.X-Invalidate-Tag + " PURGED");
                 return (synth(200, "PURGED"));
         }
         elseif (req.http.X-Invalidate-Host && req.http.X-Invalidate-Base-Path) {
-            std.log(req.http.X-Invalidate-Host + req.http.X-Invalidate-Base-Path + "PURGED");
+            std.log(req.http.X-Invalidate-Host + " " + req.http.X-Invalidate-Base-Path + "PURGED");
             ban("req.http.host == " + req.http.X-Invalidate-Host + " && req.url ~ ^" + req.http.X-Invalidate-Base-Path);
                 return (synth(200, "PURGED"));
         }
@@ -63,19 +63,19 @@ sub handle_flexible_purge_requests {
             if (req.http.X-Invalidate-Tag) {
                 std.log("X-Invalidate-Tag regex based purge");
                 ban("req.http.X-Application-Tag == " + req.http.X-Invalidate-Tag + " && req.http.X-FPFIS-Application-Path ~ " + req.http.X-Invalidate-Regexp);
-                std.log(req.http.X-Invalidate-Tag + req.http.X-Invalidate-Regexp + "PURGED");
+                std.log(req.http.X-Invalidate-Tag + " " + req.http.X-Invalidate-Regexp + " PURGED");
                     return (synth(200, "PURGED"));
             }
             else if (req.http.X-Invalidate-Host) {
-                std.log("X-Invalidate-xxx regex based purge");
+                std.log("X-Invalidate-Host regex based purge");
                 ban("req.http.host == " + req.http.X-Invalidate-Host + " && req.http.X-FPFIS-Application-Path ~ " + req.http.X-Invalidate-Regexp);
-                std.log(req.http.X-Invalidate-Host + req.http.X-Invalidate-Regexp + "PURGED");
+                std.log(req.http.X-Invalidate-Host + " " + req.http.X-Invalidate-Regexp + " PURGED");
                     return (synth(200, "PURGED"));
             }
         }
     }
     else {
-        std.log("ERROR, bad type:" + req.http.X-Invalidate-Type);
+        std.log("ERROR, bad type: " + req.http.X-Invalidate-Type);
         return (synth(400, "ERROR"));
     }
 }

--- a/content_purge.vcl
+++ b/content_purge.vcl
@@ -62,13 +62,13 @@ sub handle_flexible_purge_requests {
         if (req.http.X-Invalidate-Regexp) {
             if (req.http.X-Invalidate-Tag) {
                 std.log("X-Invalidate-Tag regex based purge");
-                ban("req.http.X-Application-Tag == " + req.http.X-Invalidate-Tag + " && req.http.X-FPFIS-Drupal-Path ~ " + req.http.X-Invalidate-Regexp);
+                ban("req.http.X-Application-Tag == " + req.http.X-Invalidate-Tag + " && req.http.X-FPFIS-Application-Path ~ " + req.http.X-Invalidate-Regexp);
                 std.log(req.http.X-Invalidate-Tag + req.http.X-Invalidate-Regexp + "PURGED");
                     return (synth(200, "PURGED"));
             }
             else if (req.http.X-Invalidate-Host) {
                 std.log("X-Invalidate-xxx regex based purge");
-                ban("req.http.host == " + req.http.X-Invalidate-Host + " && req.url ~ " + req.http.X-Invalidate-Regexp);
+                ban("req.http.host == " + req.http.X-Invalidate-Host + " && req.http.X-FPFIS-Application-Path ~ " + req.http.X-Invalidate-Regexp);
                 std.log(req.http.X-Invalidate-Host + req.http.X-Invalidate-Regexp + "PURGED");
                     return (synth(200, "PURGED"));
             }

--- a/test/151-test-flexible-purge-regex-multiple.vtc
+++ b/test/151-test-flexible-purge-regex-multiple.vtc
@@ -15,7 +15,7 @@ varnish v1 -vcl+backend {
   include "test/assets/salted.vcl";
   sub vcl_recv {
     set req.http.X-FPFIS-Application-Base-Path = "/";
-    set req.http.X-FPFIS-Drupal-Path = req.url;
+    set req.http.X-FPFIS-Application-Path = regsub(req.url, "^(\/)/*(.*)$", "\2");
     set req.http.X-Application-Tag = "Awesome-Drupal";
 
   }
@@ -50,14 +50,14 @@ client c1 {
 
 # Client 2, tries to purge without creds :
 client c2 {
-    txreq -req PURGE -url "/asset.js" -hdr "X-Invalidate-Tag: Awesome-Drupal" -hdr "X-Invalidate-Regexp: /(asset.css|asset.js)" -hdr "X-Invalidate-Type: regexp-multiple" -hdr "Host: europa.eu"
+    txreq -req PURGE -url "/asset.js" -hdr "X-Invalidate-Tag: Awesome-Drupal" -hdr "X-Invalidate-Regexp: (^asset.css|^asset.js)" -hdr "X-Invalidate-Type: regexp-multiple" -hdr "Host: europa.eu"
     rxresp
     expect resp.status == 403
 }
 
 # Client 3, tries to simple purge the URL :
 client c3 {
-    txreq -req PURGE -url "/asset.js" -hdr "X-Invalidate-Tag: Awesome-Drupal" -hdr "X-Invalidate-Regexp: /(asset.css|asset.js)" -hdr "X-Invalidate-Type: regexp-multiple" -hdr "Authorization: Basic aW52YWxpZGF0ZTp0ZXN0" -hdr "Host: europa.eu"
+    txreq -req PURGE -url "/asset.js" -hdr "X-Invalidate-Tag: Awesome-Drupal" -hdr "X-Invalidate-Regexp: (^asset.css|^asset.js)" -hdr "X-Invalidate-Type: regexp-multiple" -hdr "Authorization: Basic aW52YWxpZGF0ZTp0ZXN0" -hdr "Host: europa.eu"
     rxresp
     expect resp.status == 200
 }
@@ -117,10 +117,10 @@ varnish v1 -expect cache_hit == 6
 varnish v1 -expect n_object == 3
 varnish v1 -expect bans_completed == 1
 
-# Run client 1, cache should miss
+# Run client 1, cache should miss except for noasset.css
 client c1 -run
 
-# asset.js should be gone, so not hit
+# noasset.css should be gone, only 2 miss
 varnish v1 -expect client_req == 14
 varnish v1 -expect cache_miss == 5
 varnish v1 -expect cache_hit == 7


### PR DESCRIPTION
- Replace **req.http.X-FPFIS-Drupal-Path** by **req.http.X-FPFIS-Application-Path**, for coherence in req.http with **http.X-FPFIS-Application-Base-Path** ("Drupal" remplaced by "Application" in new varnish configuration)
- Fix test 151: 
  - add req.http.X-FPFIS-Application-Path
  - remove first "/" in X-Invalidate-Regexp
  - fix X-Invalidate-Regexp to avoid clearing noasset.css
